### PR TITLE
build(deps-dev): bump typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "prettier": "^3.3.3",
         "prettier-eslint": "^16.3.0",
-        "typescript": "^5.5.4"
+        "typescript": "^5.6.2"
       },
       "engines": {
         "node": ">=20"
@@ -4680,9 +4680,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8059,9 +8059,9 @@
       }
     },
     "typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@typescript-eslint/parser": "^7.13.0",
         "@vercel/ncc": "^0.38.1",
         "eslint": "^8.57.0",
-        "eslint-plugin-github": "^4.10.2",
+        "eslint-plugin-github": "^5.0.1",
         "eslint-plugin-jest": "^28.8.3",
         "eslint-plugin-jsonc": "^2.16.0",
         "eslint-plugin-prettier": "^5.2.1",
@@ -1630,9 +1630,9 @@
       }
     },
     "node_modules/eslint-plugin-github": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.10.2.tgz",
-      "integrity": "sha512-F1F5aAFgi1Y5hYoTFzGQACBkw5W1hu2Fu5FSTrMlXqrojJnKl1S2pWO/rprlowRQpt+hzHhqSpsfnodJEVd5QA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.1.tgz",
+      "integrity": "sha512-qbXG3wL5Uh2JB92EKeX2hPtO9c/t75qVxQjVLYuTFfhHifLZzv9CBvLCvoaBhLrAC/xTMVht7DK/NofYK8X4Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6069,9 +6069,9 @@
       }
     },
     "eslint-plugin-github": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.10.2.tgz",
-      "integrity": "sha512-F1F5aAFgi1Y5hYoTFzGQACBkw5W1hu2Fu5FSTrMlXqrojJnKl1S2pWO/rprlowRQpt+hzHhqSpsfnodJEVd5QA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.1.tgz",
+      "integrity": "sha512-qbXG3wL5Uh2JB92EKeX2hPtO9c/t75qVxQjVLYuTFfhHifLZzv9CBvLCvoaBhLrAC/xTMVht7DK/NofYK8X4Dg==",
       "dev": true,
       "requires": {
         "@github/browserslist-config": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "eslint-plugin-prettier": "^5.2.1",
     "prettier": "^3.3.3",
     "prettier-eslint": "^16.3.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@typescript-eslint/parser": "^7.13.0",
     "@vercel/ncc": "^0.38.1",
     "eslint": "^8.57.0",
-    "eslint-plugin-github": "^4.10.2",
+    "eslint-plugin-github": "^5.0.1",
     "eslint-plugin-jest": "^28.8.3",
     "eslint-plugin-jsonc": "^2.16.0",
     "eslint-plugin-prettier": "^5.2.1",


### PR DESCRIPTION
Bumps the npm-development group with 1 update in the / directory: [typescript](https://github.com/microsoft/TypeScript).


Updates `typescript` from 5.5.4 to 5.6.2
- [Release notes](https://github.com/microsoft/TypeScript/releases)
- [Changelog](https://github.com/microsoft/TypeScript/blob/main/azure-pipelines.release.yml)
- [Commits](https://github.com/microsoft/TypeScript/compare/v5.5.4...v5.6.2)

---
updated-dependencies:
- dependency-name: typescript dependency-type: direct:development update-type: version-update:semver-minor dependency-group: npm-development ...